### PR TITLE
Issue #28: All resources in the sepsis API should have a last_modified

### DIFF
--- a/bpam/apps/sepsis/migrations/0021_add_last_modified.py
+++ b/bpam/apps/sepsis/migrations/0021_add_last_modified.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import datetime
+from django.utils.timezone import utc
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sepsis', '0020_auto_20160824_1322'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='deeplcmstrack',
+            name='last_modified',
+            field=models.DateTimeField(default=datetime.datetime(2016, 8, 25, 14, 4, 7, 555198, tzinfo=utc), auto_now=True), preserve_default=False,),
+        migrations.AddField(
+            model_name='genomicsmiseqfile',
+            name='last_modified',
+            field=models.DateTimeField(default=datetime.datetime(2016, 8, 25, 14, 4, 14, 893113, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='genomicspacbiofile',
+            name='last_modified',
+            field=models.DateTimeField(default=datetime.datetime(2016, 8, 25, 14, 4, 18, 948512, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='growthmethod',
+            name='last_modified',
+            field=models.DateTimeField(default=datetime.datetime(2016, 8, 25, 14, 4, 24, 894584, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='host',
+            name='last_modified',
+            field=models.DateTimeField(default=datetime.datetime(2016, 8, 25, 14, 4, 33, 447192, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='metabolomicstrack',
+            name='last_modified',
+            field=models.DateTimeField(default=datetime.datetime(2016, 8, 25, 14, 4, 38, 487932, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='miseqgenomicsmethod',
+            name='last_modified',
+            field=models.DateTimeField(default=datetime.datetime(2016, 8, 25, 14, 4, 45, 932, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='miseqtrack',
+            name='last_modified',
+            field=models.DateTimeField(default=datetime.datetime(2016, 8, 25, 14, 4, 50, 395851, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='pacbiogenomicsmethod',
+            name='last_modified',
+            field=models.DateTimeField(default=datetime.datetime(2016, 8, 25, 14, 4, 55, 959789, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='pacbiotrack',
+            name='last_modified',
+            field=models.DateTimeField(default=datetime.datetime(2016, 8, 25, 14, 5, 2, 782599, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='proteomicsfile',
+            name='last_modified',
+            field=models.DateTimeField(default=datetime.datetime(2016, 8, 25, 14, 5, 7, 472949, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='proteomicsmethod',
+            name='last_modified',
+            field=models.DateTimeField(default=datetime.datetime(2016, 8, 25, 14, 5, 24, 658140, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='rnahiseqtrack',
+            name='last_modified',
+            field=models.DateTimeField(default=datetime.datetime(2016, 8, 25, 14, 5, 27, 973797, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='sepsissample',
+            name='last_modified',
+            field=models.DateTimeField(default=datetime.datetime(2016, 8, 25, 13, 59, 32, 954419, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='swathmstrack',
+            name='last_modified',
+            field=models.DateTimeField(default=datetime.datetime(2016, 8, 25, 14, 5, 35, 163558, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='transcriptomicsfile',
+            name='last_modified',
+            field=models.DateTimeField(default=datetime.datetime(2016, 8, 25, 14, 5, 37, 850430, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='transcriptomicsmethod',
+            name='last_modified',
+            field=models.DateTimeField(default=datetime.datetime(2016, 8, 25, 14, 5, 40, 393353, tzinfo=utc), auto_now=True),
+            preserve_default=False,
+        ),
+    ]

--- a/bpam/apps/sepsis/models.py
+++ b/bpam/apps/sepsis/models.py
@@ -19,6 +19,8 @@ class Host(models.Model):
     health_state = models.CharField('Host Health State', max_length=200, blank=True, null=True)
     disease_status = models.CharField('Host Disease Status', max_length=200, blank=True, null=True)
 
+    last_modified = models.DateTimeField(auto_now=True)
+
     class Meta:
         verbose_name = 'Host'
 
@@ -39,6 +41,8 @@ class GrowthMethod(models.Model):
                                              blank=True,
                                              null=True, )
     growth_condition_media = models.CharField('Growth condition media', max_length=200, blank=True, null=True)
+
+    last_modified = models.DateTimeField(auto_now=True)
 
     class Meta:
         verbose_name = 'Growth Method'
@@ -61,6 +65,8 @@ class MiseqGenomicsMethod(models.Model):
     insert_size_range = models.CharField('Insert Size Range', max_length=20, blank=True, null=True)
     sequencer = models.CharField('Sequencer', max_length=100, blank=True, null=True)
     analysis_software_version = models.CharField('Analysis Software Version', max_length=20, blank=True, null=True)
+
+    last_modified = models.DateTimeField(auto_now=True)
 
     class Meta:
         verbose_name = 'Miseq Genomics Method'
@@ -86,6 +92,8 @@ class PacBioGenomicsMethod(models.Model):
     cell_position = models.CharField('Cell Position', max_length=60, blank=True, null=True)
     rs_version = models.CharField('RS Version', max_length=100, blank=True, null=True)
 
+    last_modified = models.DateTimeField(auto_now=True)
+
     class Meta:
         verbose_name = 'PacBio Genomics Method'
 
@@ -106,6 +114,8 @@ class ProteomicsMethod(models.Model):
     mass_spectrometer = models.CharField('Mass Spectrometer', max_length=100, blank=True, null=True)
     aquisition_mode = models.CharField('Acquisition Mode / fragmentation', max_length=100, blank=True, null=True)
 
+    last_modified = models.DateTimeField(auto_now=True)
+
     class Meta:
         verbose_name = 'Proteomics Method'
 
@@ -125,6 +135,8 @@ class TranscriptomicsMethod(models.Model):
     insert_size_range = models.CharField('Insert Size Range', max_length=20, blank=True, null=True)
     sequencer = models.CharField('Sequencer', max_length=100, blank=True, null=True)
     casava_version = models.CharField('CASAVA Version', max_length=20, blank=True, null=True)
+
+    last_modified = models.DateTimeField(auto_now=True)
 
     class Meta:
         verbose_name = 'Transcriptomics Method'
@@ -175,6 +187,8 @@ class SampleTrack(models.Model):
     archive_ingestion_date = models.DateField('Archive Ingestion Date', blank=True, null=True, help_text='YYYY-MM-DD')
     curation_url = models.URLField('Curation URL', blank=True, null=True)
     dataset_url = models.URLField('Download URL', blank=True, null=True)
+
+    last_modified = models.DateTimeField(auto_now=True)
 
     def __unicode__(self):
         return u'{} {} {}'.format(self.bpa_id, self.taxon_or_organism, self.omics)
@@ -267,6 +281,7 @@ class SepsisSample(models.Model):
     propagation =  models.CharField('Propagation', max_length=200, blank=True, null=True)
     collected_by = models.CharField('Collected By', max_length=200, blank=True, null=True)
 
+    last_modified = models.DateTimeField(auto_now=True)
 
     def __unicode__(self):
         return ' '.join([e for e in (self.bpa_id.get_short_name(), self.taxon_or_organism, self.strain_or_isolate) if e])
@@ -280,6 +295,8 @@ class SepsisSequenceFile(SequenceFile):
 
     project_name = 'sepsis'
     sample = models.ForeignKey(SepsisSample, related_name='%(app_label)s_%(class)s_files')
+
+    last_modified = models.DateTimeField(auto_now=True)
 
     def __unicode__(self):
         return u'{}'.format(self.filename)


### PR DESCRIPTION
@aahunter added last_modified to all the models in sepsis.
That was enough for the fields to show up in the API as well, because there were no customised serializers that prevents that.

``Projects`` and ``bpa_ids`` are common models not defined in sepsis, so I didn't add the last_modified field to those.
I think that's ok, but let me know if you want last_modified on those models as well.
 