### PR TITLE
Add tracker models for Marine Microbes

### DIFF
--- a/bpam/apps/common/admin.py
+++ b/bpam/apps/common/admin.py
@@ -185,57 +185,6 @@ class CommonMetagenomicAdmin(BPAImportExportModelAdmin):
     search_fields = ('extraction_id', 'facility__name', 'comments')
 
 
-# TransferLog
-class CommonTransferLogResource(resources.ModelResource):
-    facility = fields.Field(attribute='facility', column_name='Sequencing facility', widget=FacilityWidget())
-    transfer_to_facility_date = DateField(attribute='transfer_to_facility_date', column_name='Date of transfer')
-    description = fields.Field(attribute='description', column_name='Description')
-    data_type = fields.Field(attribute='data_type', column_name='Data type')
-    folder_name = fields.Field(attribute='folder_name', column_name='Folder name')
-    transfer_to_archive_date = DateField(attribute='transfer_to_archive_date',
-                                         column_name='Date of transfer to archive')
-    notes = fields.Field(attribute='notes', column_name='Notes')
-    ticket_url = fields.Field(attribute='ticket_url', column_name='Ticket URL')
-    downloads_url = fields.Field(attribute='downloads_url', column_name='Download')
-
-    class Meta:
-        abstract = True
-        import_id_fields = ('folder_name', )
-
-
-class CommonTransferLogAdmin(BPAImportExportModelAdmin):
-
-    def show_downloads_url(self, obj):
-        try:
-            short = obj.downloads_url.split("/")[-2]
-            return format_html("<a href='{url}'>{short}</a>", url=obj.downloads_url, short=short)
-        except IndexError:
-            return ""
-
-    show_downloads_url.short_description = "Downloads URL"
-    show_downloads_url.allow_tags = True
-
-    def show_ticket_url(self, obj):
-        ticket_url = TICKET_URL + obj.ticket_url
-        return format_html("<a href='{ticket_url}'>{url}</a>", url=obj.ticket_url, ticket_url=ticket_url)
-
-    show_ticket_url.short_description = "Ticket URL"
-    show_ticket_url.allow_tags = True
-
-    date_hierarchy = 'transfer_to_archive_date'
-
-    list_display = ('facility', 'transfer_to_facility_date', 'description', 'data_type', 'folder_name',
-                    'transfer_to_archive_date', 'notes', 'show_ticket_url', 'show_downloads_url')
-
-    list_filter = ('facility',
-                   'transfer_to_facility_date',
-                   'transfer_to_archive_date',
-                   'data_type', )
-
-    search_fields = ('facility__name', 'transfer_to_facility_date', 'description', 'data_type', 'folder_name',
-                     'transfer_to_archive_date', 'notes', 'ticket_url', 'downloads_url')
-
-
 class CommonDataSetAdmin(BPAImportExportModelAdmin):
     date_hierarchy = 'transfer_to_archive_date'
 

--- a/bpam/apps/common/models.py
+++ b/bpam/apps/common/models.py
@@ -139,33 +139,6 @@ class DataSet(models.Model):
         return '{}'.format(self.name)
 
 
-class TransferLog(models.Model):
-    """ Notes transfer to CCG """
-
-    facility = models.ForeignKey(Facility,
-                                 related_name='%(app_label)s_%(class)s_facility',
-                                 verbose_name='Sequencing Facility',
-                                 blank=True,
-                                 null=True)
-    transfer_to_facility_date = models.DateField("Transfer to Facility Date")
-    description = models.CharField("Description", max_length=100)
-    data_type = models.CharField("Data Type", max_length=50)
-    folder_name = models.CharField("Folder", max_length=100)
-    transfer_to_archive_date = models.DateField("Transfer to Archive Date")
-    notes = models.TextField('Notes', blank=True, null=True)
-
-    ticket_url = models.URLField('Dataset')
-    downloads_url = models.URLField('Downloads')
-
-    class Meta:
-        abstract = True
-        verbose_name = 'Transfer Log'
-        verbose_name_plural = 'Transfers'
-
-    def __str__(self):
-        return "{} {}".format(self.facility, self.description)
-
-
 class BPAMirror(models.Model):
     """ A download site, offering the BPA Archive catalogue via a base prefix """
 

--- a/bpam/apps/marine_microbes/admin/admin.py
+++ b/bpam/apps/marine_microbes/admin/admin.py
@@ -6,12 +6,15 @@ from import_export import fields, widgets
 from apps.common.admin import DateField
 from apps.common.admin import BPAImportExportModelAdmin, BPAModelResource, isinteger, istime, isshorttime, isdecimal
 
-from ..models import OpenWaterContextual
-from ..models import CoastalContextual
-from ..models import MMSite
-from ..models import MetagenomicsTrack
-from ..models import Amplicon16STrack
-from ..models import Amplicon18STrack
+from ..models import (
+    OpenWaterContextual,
+    CoastalContextual,
+    MMSite,
+    MetagenomicsTrack,
+    MetatranscriptomeTrack,
+    AmpliconA16STrack,
+    Amplicon16STrack,
+    Amplicon18STrack)
 
 
 DEGREES = u'°'
@@ -400,5 +403,7 @@ class ContextualOpenWaterAdmin(CommonAdmin):
 admin.site.register(CoastalContextual, ContextualCoastalAdmin)
 admin.site.register(OpenWaterContextual, ContextualOpenWaterAdmin)
 admin.site.register(MetagenomicsTrack)
+admin.site.register(MetatranscriptomeTrack)
 admin.site.register(Amplicon16STrack)
+admin.site.register(AmpliconA16STrack)
 admin.site.register(Amplicon18STrack)

--- a/bpam/apps/marine_microbes/admin/admin.py
+++ b/bpam/apps/marine_microbes/admin/admin.py
@@ -4,13 +4,10 @@ from django.contrib import admin
 from import_export import fields, widgets
 
 from apps.common.admin import DateField
-from apps.common.admin import CommonTransferLogResource
-from apps.common.admin import CommonTransferLogAdmin
 from apps.common.admin import BPAImportExportModelAdmin, BPAModelResource, isinteger, istime, isshorttime, isdecimal
 
 from ..models import OpenWaterContextual
 from ..models import CoastalContextual
-from ..models import TransferLog
 from ..models import MMSite
 from ..models import MetagenomicsTrack
 from ..models import Amplicon16STrack
@@ -18,16 +15,6 @@ from ..models import Amplicon18STrack
 
 
 DEGREES = u'°'
-
-
-class TransferLogResource(CommonTransferLogResource):
-
-    class Meta(CommonTransferLogResource.Meta):
-        model = TransferLog
-
-
-class TransferLogAdmin(CommonTransferLogAdmin):
-    resource_class = TransferLogResource
 
 
 class CommonAdmin(BPAImportExportModelAdmin):
@@ -410,7 +397,6 @@ class ContextualOpenWaterAdmin(CommonAdmin):
         }), )
 
 
-admin.site.register(TransferLog, TransferLogAdmin)
 admin.site.register(CoastalContextual, ContextualCoastalAdmin)
 admin.site.register(OpenWaterContextual, ContextualOpenWaterAdmin)
 admin.site.register(MetagenomicsTrack)

--- a/bpam/apps/marine_microbes/migrations/0028_auto_20170403_1403.py
+++ b/bpam/apps/marine_microbes/migrations/0028_auto_20170403_1403.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('marine_microbes', '0027_auto_20161025_1430'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='transferlog',
+            name='facility',
+        ),
+        migrations.DeleteModel(
+            name='TransferLog',
+        ),
+    ]

--- a/bpam/apps/marine_microbes/migrations/0029_auto_20170403_1437.py
+++ b/bpam/apps/marine_microbes/migrations/0029_auto_20170403_1437.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('common', '0013_auto_20170328_1527'),
+        ('marine_microbes', '0028_auto_20170403_1403'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='AmpliconA16STrack',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('data_type', models.IntegerField(blank=True, null=True, verbose_name=b'Data Type', choices=[(1, b'Pre-pilot'), (2, b'Pilot'), (3, b'Main dataset')])),
+                ('description', models.CharField(max_length=1024, null=True, verbose_name=b'Description', blank=True)),
+                ('omics', models.CharField(max_length=50, null=True, verbose_name=b'Omics Type', blank=True)),
+                ('analytical_platform', models.CharField(max_length=100, null=True, verbose_name=b'Analytical Platform', blank=True)),
+                ('facility', models.CharField(max_length=100, null=True, verbose_name=b'Facility', blank=True)),
+                ('work_order', models.CharField(max_length=50, null=True, verbose_name=b'Work Order', blank=True)),
+                ('contextual_data_submission_date', models.DateField(help_text=b'YYYY-MM-DD', null=True, verbose_name=b'Contextual Data Submission Date', blank=True)),
+                ('sample_submission_date', models.DateField(help_text=b'YYYY-MM-DD', null=True, verbose_name=b'Sample Submission Date', blank=True)),
+                ('data_generated', models.NullBooleanField(default=False, verbose_name=b'Data Generated')),
+                ('dataset_url', models.URLField(null=True, verbose_name=b'Download URL', blank=True)),
+                ('in_data_portal', models.BooleanField(verbose_name=b'Data ingested into data portal')),
+                ('last_modified', models.DateTimeField(auto_now=True)),
+                ('bpa_id', models.ForeignKey(verbose_name=b'BPA ID', to='common.BPAUniqueID', help_text=b'Bioplatforms Australia Sample ID', null=True)),
+            ],
+            options={
+                'verbose_name': 'Track Amplicon A16S',
+                'verbose_name_plural': 'Track Amplicon A16S',
+            },
+        ),
+        migrations.CreateModel(
+            name='MetatranscriptomeTrack',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('data_type', models.IntegerField(blank=True, null=True, verbose_name=b'Data Type', choices=[(1, b'Pre-pilot'), (2, b'Pilot'), (3, b'Main dataset')])),
+                ('description', models.CharField(max_length=1024, null=True, verbose_name=b'Description', blank=True)),
+                ('omics', models.CharField(max_length=50, null=True, verbose_name=b'Omics Type', blank=True)),
+                ('analytical_platform', models.CharField(max_length=100, null=True, verbose_name=b'Analytical Platform', blank=True)),
+                ('facility', models.CharField(max_length=100, null=True, verbose_name=b'Facility', blank=True)),
+                ('work_order', models.CharField(max_length=50, null=True, verbose_name=b'Work Order', blank=True)),
+                ('contextual_data_submission_date', models.DateField(help_text=b'YYYY-MM-DD', null=True, verbose_name=b'Contextual Data Submission Date', blank=True)),
+                ('sample_submission_date', models.DateField(help_text=b'YYYY-MM-DD', null=True, verbose_name=b'Sample Submission Date', blank=True)),
+                ('data_generated', models.NullBooleanField(default=False, verbose_name=b'Data Generated')),
+                ('dataset_url', models.URLField(null=True, verbose_name=b'Download URL', blank=True)),
+                ('in_data_portal', models.BooleanField(verbose_name=b'Data ingested into data portal')),
+                ('last_modified', models.DateTimeField(auto_now=True)),
+                ('bpa_id', models.ForeignKey(verbose_name=b'BPA ID', to='common.BPAUniqueID', help_text=b'Bioplatforms Australia Sample ID', null=True)),
+            ],
+            options={
+                'verbose_name': 'Track Metatranscriptome',
+                'verbose_name_plural': 'Track Metatranscriptome',
+            },
+        ),
+        migrations.RemoveField(
+            model_name='amplicon16strack',
+            name='archive_ingestion_date',
+        ),
+        migrations.RemoveField(
+            model_name='amplicon16strack',
+            name='curation_url',
+        ),
+        migrations.RemoveField(
+            model_name='amplicon16strack',
+            name='growth_media',
+        ),
+        migrations.RemoveField(
+            model_name='amplicon16strack',
+            name='replicate',
+        ),
+        migrations.RemoveField(
+            model_name='amplicon16strack',
+            name='serovar',
+        ),
+        migrations.RemoveField(
+            model_name='amplicon16strack',
+            name='strain_or_isolate',
+        ),
+        migrations.RemoveField(
+            model_name='amplicon16strack',
+            name='taxon_or_organism',
+        ),
+        migrations.RemoveField(
+            model_name='amplicon18strack',
+            name='archive_ingestion_date',
+        ),
+        migrations.RemoveField(
+            model_name='amplicon18strack',
+            name='curation_url',
+        ),
+        migrations.RemoveField(
+            model_name='amplicon18strack',
+            name='growth_media',
+        ),
+        migrations.RemoveField(
+            model_name='amplicon18strack',
+            name='replicate',
+        ),
+        migrations.RemoveField(
+            model_name='amplicon18strack',
+            name='serovar',
+        ),
+        migrations.RemoveField(
+            model_name='amplicon18strack',
+            name='strain_or_isolate',
+        ),
+        migrations.RemoveField(
+            model_name='amplicon18strack',
+            name='taxon_or_organism',
+        ),
+        migrations.RemoveField(
+            model_name='metagenomicstrack',
+            name='archive_ingestion_date',
+        ),
+        migrations.RemoveField(
+            model_name='metagenomicstrack',
+            name='curation_url',
+        ),
+        migrations.RemoveField(
+            model_name='metagenomicstrack',
+            name='growth_media',
+        ),
+        migrations.RemoveField(
+            model_name='metagenomicstrack',
+            name='replicate',
+        ),
+        migrations.RemoveField(
+            model_name='metagenomicstrack',
+            name='serovar',
+        ),
+        migrations.RemoveField(
+            model_name='metagenomicstrack',
+            name='strain_or_isolate',
+        ),
+        migrations.RemoveField(
+            model_name='metagenomicstrack',
+            name='taxon_or_organism',
+        ),
+        migrations.AddField(
+            model_name='amplicon16strack',
+            name='description',
+            field=models.CharField(max_length=1024, null=True, verbose_name=b'Description', blank=True),
+        ),
+        migrations.AddField(
+            model_name='amplicon16strack',
+            name='in_data_portal',
+            field=models.BooleanField(default=False, verbose_name=b'Data ingested into data portal'),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='amplicon18strack',
+            name='description',
+            field=models.CharField(max_length=1024, null=True, verbose_name=b'Description', blank=True),
+        ),
+        migrations.AddField(
+            model_name='amplicon18strack',
+            name='in_data_portal',
+            field=models.BooleanField(default=False, verbose_name=b'Data ingested into data portal'),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='metagenomicstrack',
+            name='description',
+            field=models.CharField(max_length=1024, null=True, verbose_name=b'Description', blank=True),
+        ),
+        migrations.AddField(
+            model_name='metagenomicstrack',
+            name='in_data_portal',
+            field=models.BooleanField(default=False, verbose_name=b'Data ingested into data portal'),
+            preserve_default=False,
+        ),
+    ]

--- a/bpam/apps/marine_microbes/models.py
+++ b/bpam/apps/marine_microbes/models.py
@@ -6,6 +6,21 @@ from apps.common.models import SequenceFile
 from apps.common.models import BPAUniqueID
 
 
+class NotInDataPortalManager(models.Manager):
+    def get_queryset(self):
+        return super(NotInDataPortalManager, self).get_queryset().filter(in_data_portal=False)
+
+
+class SampleProcessingManager(NotInDataPortalManager):
+    def get_queryset(self):
+        return super(SampleProcessingManager, self).get_queryset().filter(data_generated=False)
+
+
+class BPAArchiveIngestManager(NotInDataPortalManager):
+    def get_queryset(self):
+        return super(BPAArchiveIngestManager, self).get_queryset().filter(data_generated=True)
+
+
 class MMSite(SampleSite):
 
     def __str__(self):
@@ -138,25 +153,19 @@ class MarineCommonContextual(models.Model):
         return "{} {}".format(self.bpa_id, self.sample_type)
 
 
-class SampleStateTrack(models.Model):
+class SampleTrack(models.Model):
 
     _DATA_TYPES = (
         (1, 'Pre-pilot'),
         (2, 'Pilot'),
         (3, 'Main dataset')
     )
-
     bpa_id = models.ForeignKey(BPAUniqueID,
                                null=True,
                                verbose_name='BPA ID',
                                help_text='Bioplatforms Australia Sample ID')
-
-    taxon_or_organism = models.CharField('Taxon or Organism', max_length=200, blank=True, null=True)
     data_type = models.IntegerField('Data Type', choices=_DATA_TYPES, blank=True, null=True)
-    strain_or_isolate = models.CharField('Strain Or Isolate', max_length=200, blank=True, null=True)
-    serovar = models.CharField('Serovar', max_length=500, blank=True, null=True)
-    growth_media = models.CharField('Growth Media', max_length=500, blank=True, null=True)
-    replicate = models.IntegerField('Replicate', blank=True, null=True)
+    description = models.CharField('Description', max_length=1024, blank=True, null=True)
     omics = models.CharField('Omics Type', max_length=50, blank=True, null=True)
     analytical_platform = models.CharField('Analytical Platform', max_length=100, blank=True, null=True)
     facility = models.CharField('Facility', max_length=100, blank=True, null=True)
@@ -164,20 +173,27 @@ class SampleStateTrack(models.Model):
     contextual_data_submission_date = models.DateField('Contextual Data Submission Date', blank=True, null=True, help_text='YYYY-MM-DD')
     sample_submission_date = models.DateField('Sample Submission Date', blank=True, null=True, help_text='YYYY-MM-DD')
     data_generated = models.NullBooleanField('Data Generated', default=False)
-    archive_ingestion_date = models.DateField('Archive Ingestion Date', blank=True, null=True, help_text='YYYY-MM-DD')
-    curation_url = models.URLField('Curation URL', blank=True, null=True)
     dataset_url = models.URLField('Download URL', blank=True, null=True)
-
+    in_data_portal = models.BooleanField('Data ingested into data portal')
     last_modified = models.DateTimeField(auto_now=True)
 
+    @classmethod
+    def get_data_type(cls, data_type_id):
+        return dict(cls._DATA_TYPES).get(data_type_id)
+
     def __unicode__(self):
-        return u'{} {} {}'.format(self.bpa_id, self.taxon_or_organism, self.omics)
+        return u'{} {}'.format(self.bpa_id, self.omics)
 
     class Meta:
         abstract = True
 
+    objects = models.Manager()
+    uningested = NotInDataPortalManager()
+    sample_processing = SampleProcessingManager()
+    bpa_archive_ingest = BPAArchiveIngestManager()
 
-class MetagenomicsTrack(SampleStateTrack):
+
+class MetagenomicsTrack(SampleTrack):
     track_type = 'Metagenomics'
 
     class Meta:
@@ -185,7 +201,23 @@ class MetagenomicsTrack(SampleStateTrack):
         verbose_name_plural = verbose_name
 
 
-class Amplicon16STrack(SampleStateTrack):
+class MetatranscriptomeTrack(SampleTrack):
+    track_type = 'Metatranscriptome'
+
+    class Meta:
+        verbose_name = 'Track Metatranscriptome'
+        verbose_name_plural = verbose_name
+
+
+class AmpliconA16STrack(SampleTrack):
+    track_type = 'Amplicon16S'
+
+    class Meta:
+        verbose_name = 'Track Amplicon A16S'
+        verbose_name_plural = verbose_name
+
+
+class Amplicon16STrack(SampleTrack):
     track_type = 'Amplicon16S'
 
     class Meta:
@@ -193,7 +225,7 @@ class Amplicon16STrack(SampleStateTrack):
         verbose_name_plural = verbose_name
 
 
-class Amplicon18STrack(SampleStateTrack):
+class Amplicon18STrack(SampleTrack):
     track_type = 'Amplicon18S'
 
     class Meta:

--- a/bpam/apps/marine_microbes/models.py
+++ b/bpam/apps/marine_microbes/models.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from django.db import models
-from apps.common.models import TransferLog as CommonTransferLog
 from apps.common.models import SampleSite
 from apps.common.models import SequenceFile
 from apps.common.models import BPAUniqueID
@@ -113,10 +112,6 @@ class MetagenomicSequenceFile(SequenceFile):
 
     class Meta:
         verbose_name_plural = "Metagenome Sequence Files"
-
-
-class TransferLog(CommonTransferLog):
-    pass
 
 
 class MarineCommonContextual(models.Model):

--- a/bpam/bpam/settings.py
+++ b/bpam/bpam/settings.py
@@ -199,10 +199,7 @@ SUIT_CONFIG = {
      # Marine Microbes
      {'app': 'marine_microbes',
       'label': 'Marine Microbes',
-      'models': ('transferlog',
-                 'metagenomicsequencefile',
-                 'ampliconsequencefile',
-                 'mmsite',
+      'models': ('mmsite',
                  'coastalcontextual',
                  'openwatercontextual',
                  'seaweedcontextual',

--- a/bpam/bpam/settings.py
+++ b/bpam/bpam/settings.py
@@ -208,6 +208,8 @@ SUIT_CONFIG = {
                  'sedimentcontextual',
                  'spongecontextual',
                  'metagenomicstrack',
+                 'metatranscriptometrack',
+                 'amplicona16strack',
                  'amplicon16strack',
                  'amplicon18strack')},
      '-',


### PR DESCRIPTION
Remove the old Tracker models.

Remove TransferLog as it is obsoleted by these changes (and wasn't ever really used anyway.)

Associated migrations.